### PR TITLE
Issue fixing 1505

### DIFF
--- a/static/dms.js
+++ b/static/dms.js
@@ -80,9 +80,32 @@ const drafts = {};
       const msgEl = document.createElement("div");
       msgEl.className = "dms-message " + (msg.is_mine ? "dms-mine" : "dms-theirs");
 
-      const textEl = document.createElement("span");
-      textEl.textContent = msg.text;
-      msgEl.appendChild(textEl);
+      const itineraryPattern = /^\[ITINERARY:(\d+):(.+?)\]([\s\S]*)?$/;
+const match = msg.text.match(itineraryPattern);
+
+if (match) {
+    const itineraryId = match[1];
+    const itineraryTitle = match[2];
+    const extraMessage = match[3] ? match[3].trim() : "";
+
+    const itineraryLink = document.createElement("a");
+    itineraryLink.href = `/itinerary/${itineraryId}`;
+    itineraryLink.style.fontWeight = "bold";
+    itineraryLink.style.display = "block";
+    itineraryLink.style.marginBottom = extraMessage ? "6px" : "0";
+    itineraryLink.textContent = `✈️ ${itineraryTitle}`;
+    msgEl.appendChild(itineraryLink);
+
+    if (extraMessage) {
+        const extraEl = document.createElement("span");
+        extraEl.textContent = extraMessage;
+        msgEl.appendChild(extraEl);
+    }
+} else {
+    const textEl = document.createElement("span");
+    textEl.textContent = msg.text;
+    msgEl.appendChild(textEl);
+}
 
       if (msg.reaction) {
         const reactionEl = document.createElement("span");

--- a/static/itinerary-display.js
+++ b/static/itinerary-display.js
@@ -316,3 +316,29 @@ function updateDots(containerId, total, activeIndex) {
             window.location.href = "/profile";
         });
     }
+
+    // show day 1 by default
+document.addEventListener("DOMContentLoaded", function() {
+    const firstDay = document.querySelector('.day-details');
+    if (firstDay) firstDay.style.display = 'block';
+    
+    const firstThumb = document.querySelector('.day-card');
+    if (firstThumb) firstThumb.classList.add('active-day');
+});
+
+// thumbnail click handler
+document.querySelectorAll('.day-card').forEach(card => {
+    card.addEventListener('click', function() {
+        const dayNum = this.dataset.day;
+
+        // hide all day details
+        document.querySelectorAll('.day-details').forEach(d => d.style.display = 'none');
+        
+        // show selected day
+        document.querySelector(`.day-details[data-day="${dayNum}"]`).style.display = 'block';
+
+        // update active thumbnail
+        document.querySelectorAll('.day-card').forEach(c => c.classList.remove('active-day'));
+        this.classList.add('active-day');
+    });
+});

--- a/static/itinerary-display.js
+++ b/static/itinerary-display.js
@@ -332,5 +332,12 @@ document.querySelectorAll('.day-card').forEach(card => {
         // update active thumbnail
         document.querySelectorAll('.day-card').forEach(c => c.classList.remove('active-day'));
         this.classList.add('active-day');
+
+        // update main image
+        const img = this.querySelector('img');
+        const mainImage = document.querySelector('.main-image img');
+        if (mainImage && img) {
+            mainImage.src = img.src;
+        }
     });
 });

--- a/static/itinerary-display.js
+++ b/static/itinerary-display.js
@@ -341,3 +341,55 @@ document.querySelectorAll('.day-card').forEach(card => {
         }
     });
 });
+
+let lightboxImages = [];
+let lightboxIndex = 0;
+
+function openLightbox(images, index) {
+    lightboxImages = images;
+    lightboxIndex = index;
+    document.getElementById('lightbox-img').src = lightboxImages[lightboxIndex];
+    document.getElementById('lightbox').classList.remove('hidden');
+}
+
+function closeLightbox() {
+    document.getElementById('lightbox').classList.add('hidden');
+}
+
+document.querySelector('.lightbox-close').addEventListener('click', closeLightbox);
+document.querySelector('.lightbox-overlay').addEventListener('click', closeLightbox);
+
+document.querySelector('.lightbox-prev').addEventListener('click', function() {
+    lightboxIndex = (lightboxIndex - 1 + lightboxImages.length) % lightboxImages.length;
+    document.getElementById('lightbox-img').src = lightboxImages[lightboxIndex];
+});
+
+document.querySelector('.lightbox-next').addEventListener('click', function() {
+    lightboxIndex = (lightboxIndex + 1) % lightboxImages.length;
+    document.getElementById('lightbox-img').src = lightboxImages[lightboxIndex];
+});
+
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') closeLightbox();
+    if (e.key === 'ArrowLeft') {
+        lightboxIndex = (lightboxIndex - 1 + lightboxImages.length) % lightboxImages.length;
+        document.getElementById('lightbox-img').src = lightboxImages[lightboxIndex];
+    }
+    if (e.key === 'ArrowRight') {
+        lightboxIndex = (lightboxIndex + 1) % lightboxImages.length;
+        document.getElementById('lightbox-img').src = lightboxImages[lightboxIndex];
+    }
+});
+
+// make detail tab photos clickable
+document.querySelectorAll('.day-details').forEach(dayDiv => {
+    const imgs = Array.from(dayDiv.querySelectorAll('img'));
+    const srcs = imgs.map(img => img.src);
+    
+    imgs.forEach((img, index) => {
+        img.style.cursor = 'pointer';
+        img.addEventListener('click', function() {
+            openLightbox(srcs, index);
+        });
+    });
+});

--- a/static/itinerary-display.js
+++ b/static/itinerary-display.js
@@ -214,8 +214,6 @@ function updateDots(containerId, total, activeIndex) {
     const shareSendBtn = document.getElementById("shareSendBtn");
     const shareCancelBtn = document.getElementById("shareCancelBtn");
     const shareItineraryTitle = document.getElementById("shareItineraryTitle");
-    console.log("shareButton:", shareButton);
-    console.log("shareSendBtn:", shareSendBtn);
 
     // open modal and load users
     shareButton.addEventListener("click", async function() {
@@ -247,14 +245,10 @@ function updateDots(containerId, total, activeIndex) {
 
     // send the itinerary
     shareSendBtn.addEventListener("click", async function() {
-        console.log("send clicked");
         const receiverId = shareUserSelect.value;
         const message = shareMessage.value.trim();
         const itineraryId = shareButton.dataset.itineraryId;
         const itineraryTitle = shareButton.dataset.itineraryTitle;
-
-        console.log("receiverId:", receiverId);
-        console.log("itineraryId:", itineraryId);
 
         if (!receiverId) {
             alert("Please select a user to send to.");
@@ -262,8 +256,6 @@ function updateDots(containerId, total, activeIndex) {
         }
 
         const formattedText = `[ITINERARY:${itineraryId}:${itineraryTitle}]${message ? '\n' + message : ''}`;
-        console.log("formattedText:", formattedText);
-        console.log("about to fetch");
 
         const response = await fetch("/api/messages", {
             method: "POST",

--- a/static/styles.css
+++ b/static/styles.css
@@ -831,13 +831,6 @@ a:hover, a:active {
     position: relative;
 }
 
-.main-image {
-    width: 100%;
-    aspect-ratio: 1 / 1;
-    background-color: var(--text-main);
-    position: center;
-}
-
 .time-block {
     border: 1px solid black;
     height: 120px;
@@ -2322,8 +2315,8 @@ a:hover, a:active {
 
 .itinerary-display-page .main-image {
     width: 100%;
-    max-width: 700px;
-    height: 340px;
+    max-width: 900px;
+    max-height: 700px;
     margin: 0 auto 20px auto;
     border-radius: 16px;
     overflow: hidden;
@@ -2507,7 +2500,6 @@ a:hover, a:active {
 }
 
 .delete-button:hover {
-    color: var(--primary);
     transform: scale(1.12);
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1590,10 +1590,6 @@ a:hover, a:active {
     margin: 0;
 }
 
-.trip-input[type="number"] {
-    -moz-appearance: textfield;
-}
-
 .budget-summary {
     max-width: 350px;
     margin: 0 auto 10px;
@@ -2296,9 +2292,13 @@ a:hover, a:active {
     margin-bottom: 20px;
 }
 
+.creator-username {
+    font-size: 38px;
+}
+
 .itinerary-display-page .creator-pic {
-    width: 65px;
-    height: 65px;
+    width: 70px;
+    height: 70px;
     border-radius: 50%;
     overflow: hidden;
     background: #e6e1e3;
@@ -2379,6 +2379,68 @@ a:hover, a:active {
     width: 100%;
     height: 100%;
     object-fit: cover;
+}
+
+.lightbox {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lightbox-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.85);
+}
+
+#lightbox-img {
+    position: relative;
+    max-width: 80%;
+    max-height: 80vh;
+    border-radius: 8px;
+    z-index: 1;
+}
+
+.lightbox-close,
+.lightbox-prev,
+.lightbox-next {
+    position: absolute;
+    background: none;
+    border: none;
+    color: white;
+    cursor: pointer;
+    z-index: 2;
+    font-size: 40px;
+    line-height: 1;
+}
+
+.lightbox-close {
+    top: 20px;
+    right: 30px;
+    font-size: 28px;
+}
+
+.lightbox-prev {
+    left: 20px;
+}
+
+.lightbox-next {
+    right: 20px;
+}
+
+.lightbox-close:hover,
+.lightbox-prev:hover,
+.lightbox-next:hover {
+    color: #e43d12;
 }
 
 .itinerary-display-page .overlay-text {

--- a/static/styles.css
+++ b/static/styles.css
@@ -2260,6 +2260,26 @@ a:hover, a:active {
 /*Search Page Styling END*/
 
 /* itinerary display page start */
+.day-card.active-day {
+    outline: 3px solid #A50034;
+    outline-offset: 2px;
+}
+
+.trip-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin: 12px 0;
+}
+
+.trip-pill {
+    background-color: #A50034;
+    color: white;
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 14px;
+}
 
 .itinerary-display-page .display-header {
     text-align: center;

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -32,18 +32,14 @@
                 {% endif %}
             </div>
 
-            <div class="trip-summary">
-                <p><strong>Destination:</strong> {{ itinerary.destination }}</p>
-                <p><strong>Travel Style:</strong> {{ itinerary.travel_style or 'Not specified' }}</p>
-                <p><strong>Budget:</strong> 
-                    {% if itinerary.budget is not none %}
-                        ${{ "%.2f"|format(itinerary.budget) }}
-                    {% else %}
-                        Not specified
-                    {% endif %}
-                </p>
-                <p><strong>Dates:</strong> {{ itinerary.start_date }} to {{ itinerary.end_date }}</p>
-            </div>
+    <div class="trip-summary">
+        <span class="trip-pill"><strong>Location: </strong> {{ itinerary.destination }}</span>
+        <span class="trip-pill"><strong>Style: </strong> {{ itinerary.travel_style or 'Not specified' }}</span>
+        <span class="trip-pill">
+            <strong>Budget: </strong> {% if itinerary.budget is not none %}${{ "%.2f"|format(itinerary.budget) }}{% else %}Not specified{% endif %}
+        </span>
+        <span class="trip-pill"><strong>Dates: </strong>{{ itinerary.start_date }} – {{ itinerary.end_date }}</span>
+    </div>
             <div class="action-buttons">
                 <!-- LIKE COLUMN -->
                 <div class="like-group">

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -92,7 +92,7 @@
             </div> <!--end of action-button-div-->
             <div class="day-thumbnails">
                 {% for day in itinerary.days %}
-                    <div class="day-card">
+                    <div class="day-card" data-day="{{ day.day_number }}">
                         {% if day.photos %}
                             <img 
                                 src="{{ url_for('static', filename='uploads/' + day.photos[0].filename) }}" 
@@ -108,6 +108,7 @@
     </div>
    <div class="right-column">
         {% for day in itinerary.days %}
+        <div class="day-details" data-day="{{ day.day_number }}" style="display: none;">
             <h3>Day {{ day.day_number }}</h3>
 
             <div class="itinerary-detail-box">
@@ -208,6 +209,7 @@
                     <p>{{ day.caption or '' }}</p>
                 </div>
             </div>
+        </div>
         {% endfor %}
     </div>
         

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -237,6 +237,14 @@
     </div>
 </div>
 
+<div id="lightbox" class="lightbox hidden">
+    <div class="lightbox-overlay"></div>
+    <button class="lightbox-close">✕</button>
+    <button class="lightbox-prev">&#8249;</button>
+    <img id="lightbox-img" src="" alt="">
+    <button class="lightbox-next">&#8250;</button>
+</div>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="{{ url_for('static', filename='itinerary-display.js') }}"></script>
 

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -19,30 +19,10 @@
 
             <div class="creator-section">
                 <div class="creator-pic"></div>
-                <p>@{{ itinerary.user.username }}</p>
+                <p class="creator-username">@{{ itinerary.user.username }}</p>
             </div>
 
-            <div class="itinerary-display-page">
-                <div class="main-image">
-                    {% if itinerary.days and itinerary.days[0].photos %}
-                <img 
-                    src="{{ url_for('static', filename='uploads/' + itinerary.days[0].photos[0].filename) }}" 
-                    alt="Main itinerary image"
-                    style="width: 100%; height: 100%; object-fit: cover;"
-                >
-                {% endif %}
-            </div>
-</div>
-
-    <div class="trip-summary">
-        <span class="trip-pill"><strong>Location: </strong> {{ itinerary.destination }}</span>
-        <span class="trip-pill"><strong>Style: </strong> {{ itinerary.travel_style or 'Not specified' }}</span>
-        <span class="trip-pill">
-            <strong>Budget: </strong> {% if itinerary.budget is not none %}${{ "%.2f"|format(itinerary.budget) }}{% else %}Not specified{% endif %}
-        </span>
-        <span class="trip-pill"><strong>Dates: </strong>{{ itinerary.start_date }} – {{ itinerary.end_date }}</span>
-    </div>
-            <div class="action-buttons">
+                        <div class="action-buttons">
                 <!-- LIKE COLUMN -->
                 <div class="like-group">
                     <button 
@@ -92,6 +72,28 @@
                 {% endif %}
 
             </div> <!--end of action-button-div-->
+
+            <div class="itinerary-display-page">
+                <div class="main-image">
+                    {% if itinerary.days and itinerary.days[0].photos %}
+                <img 
+                    src="{{ url_for('static', filename='uploads/' + itinerary.days[0].photos[0].filename) }}" 
+                    alt="Main itinerary image"
+                    style="width: 100%; height: 100%; object-fit: cover;"
+                >
+                {% endif %}
+            </div>
+</div>
+
+    <div class="trip-summary">
+        <span class="trip-pill"><strong>Location: </strong> {{ itinerary.destination }}</span>
+        <span class="trip-pill"><strong>Style: </strong> {{ itinerary.travel_style or 'Not specified' }}</span>
+        <span class="trip-pill">
+            <strong>Budget: </strong> {% if itinerary.budget is not none %}${{ "%.2f"|format(itinerary.budget) }}{% else %}Not specified{% endif %}
+        </span>
+        <span class="trip-pill"><strong>Dates: </strong>{{ itinerary.start_date }} – {{ itinerary.end_date }}</span>
+    </div>
+
             <div class="day-thumbnails">
                 {% for day in itinerary.days %}
                     <div class="day-card" data-day="{{ day.day_number }}">

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -14,8 +14,6 @@
        
     <div class="page-wrapper">
         <div class="middle-column">
-    
-            <h2>{{ itinerary.title }}</h2>
 
             <div class="creator-section">
                 <div class="creator-pic"></div>
@@ -72,6 +70,9 @@
                 {% endif %}
 
             </div> <!--end of action-button-div-->
+
+            
+            <h2>{{ itinerary.title }}</h2>
 
             <div class="itinerary-display-page">
                 <div class="main-image">

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -22,15 +22,17 @@
                 <p>@{{ itinerary.user.username }}</p>
             </div>
 
-            <div class="main-image">
-                {% if itinerary.days and itinerary.days[0].photos %}
-                    <img 
-                        src="{{ url_for('static', filename='uploads/' + itinerary.days[0].photos[0].filename) }}" 
-                        alt="Main itinerary image"
-                        style="width: 100%; height: 100%; object-fit: cover;"
-                    >
+            <div class="itinerary-display-page">
+                <div class="main-image">
+                    {% if itinerary.days and itinerary.days[0].photos %}
+                <img 
+                    src="{{ url_for('static', filename='uploads/' + itinerary.days[0].photos[0].filename) }}" 
+                    alt="Main itinerary image"
+                    style="width: 100%; height: 100%; object-fit: cover;"
+                >
                 {% endif %}
             </div>
+</div>
 
     <div class="trip-summary">
         <span class="trip-pill"><strong>Location: </strong> {{ itinerary.destination }}</span>

--- a/templates/itinerary-display.html
+++ b/templates/itinerary-display.html
@@ -76,12 +76,11 @@
                     id="shareButton"
                     class="share-button"
                     type="button"
-                    data-itinerary-id="{{ itinerary_id }}"
-                    data-itinerary-title="Itinerary Title"
+                    data-itinerary-id="{{ itinerary.id }}"
+                    data-itinerary-title="{{ itinerary.title }}"
                 >
-                    <i id="shareIcon" class="fa-regular fa-share-from-square"></i>
+                <i id="shareIcon" class="fa-regular fa-share-from-square"></i>
                 </button>
-
                 {% if is_owner %}
                 <button 
                     id="deleteButton" 


### PR DESCRIPTION
Firstly, i fixed the bug that wasn't displaying sent itineraries in displays correctly.

Secondly I made major improvements to the itinerary display page which previously had unresponsive thumbnails, a main image that was too large to see properly, and an inability to navigate through day details smoothly. Also it was displaying itinerary details as a single scroll which was 1 unusable 2 defeated the purpose of having thumbnails to navigate through the pages.
Here are the changes:

- Action buttons moved:  the action-buttons div (like, save, share, delete) was moved from below the main image to directly below the creator-section div, so it sits under the username before the image.
- Username styled: the creator username <p> tag was given the class creator-username for independent font size styling.
- Trip summary pills:  the trip-summary div was redesigned from a vertical list to horizontal pills using .trip-pill spans with emoji icons.
- Day navigation: each .day-card thumbnail was given a data-day attribute, and each day's right column content was wrapped in a .day-details div with a matching data-day attribute. Clicking a thumbnail now shows only that day's details and updates the main image.
- Main image wrapper: the .main-image div was wrapped in a .itinerary-display-page div to scope its CSS correctly without affecting other elements.

Testing note: To properly test the day navigation and main image switching, create a test itinerary that has a different photo uploaded for each day. This will confirm that clicking each thumbnail correctly updates both the main image and the right column details.