### PR TITLE
Refactor and clean up duplicated frontend styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,7 +202,7 @@ def homepage():
         .outerjoin(Like, Like.itinerary_id == Itinerary.id)
         .group_by(Itinerary.id)
         .order_by(db.func.count(Like.id).desc())
-        .limit(5)
+        .limit(6)
         .all()
     )
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,16 +1,19 @@
 :root {
     --primary: #A50034;
     --primary-dark: #8a002c;
-
     --background: #faf7f8;
     --surface: #ffffff;
-
     --text-main: #222222;
     --text-secondary: #666666;
-
     --border-soft: #d8b7c0;
-
     --white-text: #ededed;
+    --primary-soft: #f7e8ed;
+    --surface-soft: #fff8fa;
+    --shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.08);
+    --shadow-hover: 0 14px 32px rgba(0, 0, 0, 0.12);
+    --radius-sm: 10px;
+    --radius-md: 16px;
+    --radius-lg: 24px;
 }
 
 body {
@@ -20,12 +23,7 @@ body {
     text-align: center;
     margin: 0; 
     padding: 0;
-}
-
-.logo {
-    display: block;
-    margin: 80px auto 20px auto;
-    width: 400px;
+    background: linear-gradient(135deg, #ffffff 0%, var(--background) 100%) !important;
 }
 
 h1 {
@@ -39,19 +37,7 @@ h2 {
     color: var(--primary-dark);
     
 }
-
 /*Homepage Styling START*/
-.homepage-header {
-    position: sticky;
-    top: 0;
-    background-color: var(--surface);
-    z-index: 10;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 40px;
-}
-
 .trending-itinerary-container {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
@@ -99,13 +85,6 @@ h2 {
     padding: 7px;
 }
 
-.account-buttons {
-  position: absolute;
-  top: 22px;
-  right: 20px;
-  font-size: 25px;
-}
-
 .btn {
     width: 100%;
       height: 48px;
@@ -130,6 +109,28 @@ h2 {
 
 .how-it-works {
     margin: 40px 0;
+}
+
+.how-it-works .steps-container {
+    flex-wrap: wrap;
+}
+
+.how-it-works .step {
+    box-shadow: var(--shadow-soft);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.how-it-works .step:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-hover);
+}
+
+.how-it-works .step,
+.how-it-works .step p,
+.how-it-works .step-title,
+.how-it-works .step-desc,
+.how-it-works .step-number {
+    color: #ffffff !important;
 }
 
 .steps-container {
@@ -568,11 +569,6 @@ a:hover, a:active {
     color: var(--surface);
 }
 
-
-.hidden {
-    display: none !important;
-}
-
 /* stack heart + count */
 .like-group {
     display: flex;
@@ -809,12 +805,6 @@ a:hover, a:active {
 }
 
 /*User Profile Styling END*/
-/* wherever your main content offset is */
-.main-content {           /* or body, or whatever wraps your page */
-    margin-left: 56px;
-    transition: margin-left 0.25s ease;
-}
-
 
 .day-thumbnails {
     display: flex;
@@ -829,13 +819,6 @@ a:hover, a:active {
     aspect-ratio: 1 / 1;
     background-color: var(--text-main);
     position: relative;
-}
-
-.time-block {
-    border: 1px solid black;
-    height: 120px;
-    padding: 10px;
-    font-weight: bold;
 }
 
 .creator-section {
@@ -905,29 +888,6 @@ a:hover, a:active {
     display: flex;
     flex-direction: column;
     flex: 1;
-}
-
-/* Links: icon + label side by side */
-.navigation-bar li a {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    color: #ededed;
-    padding: 20px 18px;
-    text-decoration: none;
-}
-
-.navigation-bar li a:hover {
-    background-color: var(--primary-dark);
-    color: #ededed;
-}
-
-/* Icons: fixed width so they don't shift */
-.navigation-bar li a i {
-    flex-shrink: 0;
-    width: 20px;
-    text-align: center;
-    font-size: 1.1rem;
 }
 
 /* Labels: hidden when collapsed */
@@ -1003,13 +963,6 @@ a:hover, a:active {
     background-color: transparent;
 }
 
-.page-wrapper {
-    margin-left: 56px; /* same as nav width */
-    display: flex;
-    height: 100vh;
-    overflow: hidden;
-}
-
 .middle-column {
     flex: 1;
     overflow-y: auto;
@@ -1018,14 +971,6 @@ a:hover, a:active {
     background-color: var(--surface);
 }
 
-.right-column {
-    width: 400px;
-    overflow-y: auto;
-    padding: 20px 0 20px 20px; 
-    border-left: 1px solid #ccc;
-    align-items: center;
-    background-color: var(--surface);
-}
 
 .itinerary-detail-box {
     display: flex;
@@ -1333,135 +1278,224 @@ a:hover, a:active {
   height: 100vh;
   display: flex;
   background-color: var(--surface);
+  background:
+            radial-gradient(circle at top left, rgba(165, 0, 52, 0.08), transparent 32%),
+            linear-gradient(135deg, #ffffff 0%, var(--background) 100%) !important;
 }
 /* SIDEBAR */
+
 .dms-sidebar {
-  width: 300px;
-  border-right: 2px solid var(--primary);
-  background: var(--surface);
-  padding: 20px;
-  overflow-y: auto;
+    width: 330px;
+    min-width: 300px;
+    background: var(--surface);
+    border-right: 1px solid var(--border-soft);
+    padding: 24px 20px;
+    overflow-y: auto;
+    box-shadow: 6px 0 22px rgba(0, 0, 0, 0.05);
+}
+
+.dms-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
 }
 
 .dms-sidebar h2 {
   margin-top: 0;
   color: var(--primary-dark);
 }
-
-.user {
-    padding: 12px;
-    border-radius: 12px;
-    cursor: pointer;
-    margin-bottom: 10px;
-    background: var(--surface);
-    border: 1.5px solid var(--primary);
-    transition: 0.2s;
-
-    justify-content: space-between;
+.dms-sidebar-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: var(--primary-soft);
+    color: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
 }
 
-.user:hover {
-  background: var(--primary);
-  color: var(--surface);
+.dms-sidebar-subtitle {
+    text-align: left;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 8px 0 20px;
+}
+
+.user {
+    display: flex !important;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius-md);
+    background: var(--surface-soft);
+    color: var(--text-main);
+    font-weight: 700;
+    box-shadow: none;
+    padding: 12px;
+    cursor: pointer;
+    margin-bottom: 10px;
+    border: 1.5px solid var(--primary);
+    transition: 0.2s;
+}
+
+.dms-body .page-wrapper {
+    height: 100vh;
+}
+
+.dms-sidebar-title {
+    margin: 4px 0 0;
+    text-align: left;
+    color: var(--primary);
+    font-size: 28px;
+}
+
+#userList {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.user:hover,
+.user.active-user {
+    background: var(--primary-soft);
+    color: var(--primary);
+    box-shadow: var(--shadow-soft);
+}
+
+.dms-chat-header {
+    min-height: 76px;
+    padding: 20px 28px;
+    background: rgba(255, 255, 255, 0.88);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border-soft);
+    color: var(--primary);
+    font-size: 18px;
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.04);
+}
+
+.dms-mine {
+    align-self: flex-end;
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--surface);
+    border-bottom-right-radius: 6px;
+}
+
+.dms-theirs {
+    background: var(--surface);
+    color: var(--text-main);
+    border: 1px solid var(--border-soft);
+    border-bottom-left-radius: 6px;
+    align-self: flex-start;
 }
 
 /* CHAT AREA */
 .dms-chat-area {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    background:
+            radial-gradient(circle at top right, rgba(165, 0, 52, 0.06), transparent 30%),
+            var(--background);
 }
 
-/* HEADER */
-.dms-chat-header {
-  padding: 20px;
-  background: var(--surface);
-  border-bottom: 2px solid var(--primary);
-  font-weight: bold;
-  color: var(--primary-dark);
-}
 .chat-profile-link,
 .chat-profile-link:link,
 .chat-profile-link:visited,
 .chat-profile-link:active {
     color: var(--primary);
+    font-weight: 900;
+
     text-decoration: none;
-    background: none;
+
+    background: transparent;
     border: none;
     box-shadow: none;
+
     display: inline;
+
     margin: 0;
     padding: 0;
 }
 
 .chat-profile-link:hover {
     text-decoration: underline;
+    color: var(--primary-dark);
+    background: transparent;
 }
+
 /* MESSAGES */
-.dms-messages {
-  flex: 1;
-  padding: 20px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-/* MESSAGE BUBBLES */
 .dms-message {
-  text-align: left;
-  max-width: 60%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  word-wrap: break-word;
-  font-size: 14px;
+    padding: 12px 15px;
+    border-radius: 18px;
+    font-size: 14px;
+    line-height: 1.5;
+    word-break: break-word;
+    text-align: left;
+    box-shadow: 0 5px 18px rgba(0, 0, 0, 0.07);
+    max-width: 60%;
+    word-wrap: break-word;
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
-
-.dms-mine {
-  align-self: flex-end;
-  background: var(--primary);
-  color: var(--surface);
-}
-
-.dms-theirs {
-  align-self: flex-start;
-  background: var(--surface);
-  color: #222;
-  border: 1px solid var(--primary);
+.dms-messages {
+    flex: 1;
+    padding: 30px 32px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 /* INPUT AREA */
 .dms-composer {
-  display: flex;
-  gap: 10px;
-  padding: 16px;
-  background: var(--surface);
-  border-top: 2px solid var(--primary);
+    display: flex;
+    gap: 12px;
+    padding: 18px 22px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(12px);
+    border-top: 1px solid var(--border-soft);
 }
 
 .dms-composer input {
-  flex: 1;
-  padding: 12px;
-  border: 1.5px solid var(--primary);
-  border-radius: 10px;
-  outline: none;
+    flex: 1;
+    height: 48px;
+    border-radius: 999px;
+    padding: 0 18px;
+    border: 1.5px solid var(--border-soft);
+    background: var(--surface);
+    outline: none;
 }
-
 .dms-composer input:focus {
   border-color: var(--primary-dark);
   box-shadow: 0 0 0 3px rgba(228, 61, 18, 0.12);
 }
 
 .dms-composer button {
-  height: 48px;
-  padding: 0 18px;
-  border-radius: 10px;
-  border: 2px solid var(--primary);
-  background: transparent;
-  color: var(--primary);
-  font-weight: bold;
-  cursor: pointer;
-  transition: 0.3s;
+    min-width: 105px;
+    height: 48px;
+    border: none;
+    border-radius: 999px;
+    background: var(--primary);
+    color: var(--surface);
+    font-weight: 900;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    cursor: pointer;
+    transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .dms-composer button:hover {
@@ -1469,17 +1503,47 @@ a:hover, a:active {
   color: var(--surface);
 }
 
+.dms-composer input:disabled {
+    background: #f1f1f1;
+    color: #999;
+}
+.dms-composer button:hover:not(:disabled) {
+    background: var(--primary-dark);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-soft);
+}
+.dms-composer button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
 /* EMPTY STATE */
 .dms-empty {
-  padding: 20px;
-  color: #777;
-  text-align: center;
+    max-width: 420px;
+    margin: auto;
+    padding: 42px 28px;
+    border-radius: 24px;
+    background: var(--surface);
+    border: 1px dashed var(--border-soft);
+    color: var(--text-secondary);
+    box-shadow: var(--shadow-soft);
+    text-align: center;
 }
-/* message reactions */
+.dms-empty i {
+    font-size: 42px;
+    color: var(--primary);
+    margin-bottom: 12px;
+}
+
+.dms-empty p {
+    margin: 0;
+    font-weight: 700;
+}
+
 .dms-message-wrapper {
-  display: flex;
-  flex-direction: column;
-  max-width: 60%;
+    max-width: 68%;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 
 .mine-wrapper {
@@ -1499,70 +1563,95 @@ a:hover, a:active {
 }
 
 .message-reaction {
-  position: absolute;
-  bottom: -14px;
-  right: 8px;
-  background: var(--surface);
-  border: 1px solid var(--primary);
-  border-radius: 50%;
-  padding: 2px 5px;
-  font-size: 13px;
+    position: absolute;
+    bottom: -14px;
+    right: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 6px;
+    background: var(--surface);
+    border: 1px solid var(--border-soft);
+    border-radius: 999px;
+    padding: 2px 6px;
+    font-size: 14px;
 }
 
 .reaction-bar {
-  display: none;
-  gap: 5px;
-  margin-top: 2px;
+    display: flex;
+    gap: 5px;
+    margin-bottom: 2px;
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .dms-message-wrapper:hover .reaction-bar {
-  display: flex;
+    display: flex;
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .reaction-btn {
-  border: 1px solid var(--primary);
-  background: var(--surface);
-  border-radius: 20px;
-  cursor: pointer;
-  padding: 3px 6px;
-  font-size: 13px;
+    border: 1px solid var(--border-soft);
+    background: var(--surface);
+    border-radius: 999px;
+    padding: 3px 6px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .reaction-btn:hover {
   background: var(--primary);
   color: var(--surface);
+  transform: translateY(-1px) scale(1.06);
+  box-shadow: var(--shadow-soft);
 }
+
 /* TIME */
+
 .message-time {
+    margin-top: 5px;
     font-size: 11px;
-    color: rgba(255,255,255,0.75);
-    margin-top: 4px;
+    opacity: 0.75;
     text-align: right;
+    color: rgba(255,255,255,0.75);
 }
 
 .dms-theirs .message-time {
-    color: #777;
+    color: var(--text-secondary);
+}
+
+.dms-mine .message-time {
+    color: rgba(255, 255, 255, 0.82);
 }
 /* DATE SEPARATOR */
+
 .date-separator {
     align-self: center;
-    background: #fffdf4;
-    border: 1px solid #ddd;
-    border-radius: 20px;
-    padding: 5px 12px;
-    font-size: 12px;
-    color: #666;
-    margin: 14px 0;
+    background: var(--surface);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-soft);
+    border-radius: 999px;
+    padding: 7px 16px;
+    font-size: 13px;
+    margin: 18px 0;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.04);
 }
 .reply-preview {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: #fffdf4;
-  border-top: 2px solid var(--primary);
-  padding: 10px 16px;
-  color: #555;
-  font-size: 14px;
+    border-top: 2px solid var(--primary);
+    font-size: 14px;
+    margin: 0 22px 12px;
+    padding: 12px 16px;
+    border-left: 4px solid var(--primary);
+    background: var(--surface);
+    border-radius: 14px;
+    color: var(--text-secondary);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: var(--shadow-soft);
 }
 
 .reply-preview button {
@@ -1570,45 +1659,44 @@ a:hover, a:active {
   background: transparent;
   color: var(--primary);
   font-size: 18px;
+  font-weight: 900;
   cursor: pointer;
 }
 
 .reply-box {
-  border-left: 3px solid var(--primary);
-  background: #f1ede4; 
-  padding: 6px 8px;
-  margin-bottom: 6px;
-  font-size: 12px;
-  color: #444;
-  border-radius: 6px;
+    margin-bottom: 8px;
+    padding: 8px 10px;
+    border-left: 4px solid rgba(255, 255, 255, 0.65);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.14);
+    font-size: 12px;
+    opacity: 0.9;
+    color: #444;
 }
+
 .reply-btn {
-  border: none;
-  background: transparent;
-  color: var(--primary-dark);
-  font-size: 12px;
-  cursor: pointer;
-  margin-top: 2px;
+    border: none;
+    background: transparent;
+    color: var(--primary);
+    font-size: 12px;
+    font-weight: 700;
+    padding: 0 4px;
+    cursor: pointer;
+    opacity: 0.75;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    margin-top: 2px;
 }
 
 .reply-btn:hover {
-  color: var(--primary);
+    color: var(--primary);
+    opacity: 1;
+    transform: translateY(-1px);
 }
-
-.hidden {
-  display: none !important;
+.dms-theirs .reply-box {
+    background: var(--primary-soft);
+    border-left-color: var(--primary);
+    color: var(--text-secondary);
 }
-/*unread message*/
-.unread-dot {
-  width: 10px;
-  height: 10px;
-  background-color: var(--primary);
-  border-radius: 50%;
-  display: inline-block;
-  flex-shrink: 0;
-}
-
-
 /*Feed Page Styling Start*/
 .card-info {
     padding: 6px 2px;
@@ -1655,11 +1743,6 @@ a:hover, a:active {
     box-shadow: 0 10px 30px rgba(0,0,0,0.2);
 }
 
-.guide-list {
-    margin: 16px 0 20px 20px;
-    line-height: 1.7;
-}
-
 
 #submit-btn {
     display: block;
@@ -1685,73 +1768,7 @@ a:hover, a:active {
 .budget-summary p {
     margin: 6px 0;
 }
-.profile-tabs {
-    display: flex;
-    justify-content: center;
-    gap: 40px;
-    margin: 30px 40px 10px;
-    padding: 10px 0;
-}
-.profile-tab {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 26px;
-    color: #000000;
-    padding-bottom: 8px;
-    transition: 0.2s;
-}
 
-.profile-tab.active {
-    color: var(--primary);
-    border-bottom: 2px solid var(--primary); 
-}
-/* hover same as buttons */
-.profile-tab:hover {
-    transform: scale(1.1);
-}
-
-
-/* User search results styling START */
-
-.user-search-results {
-    max-width: 700px;
-    margin: 20px auto 35px auto;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.user-result-card,
-.user-result-card:link,
-.user-result-card:visited {
-    display: flex;
-    align-items: center;
-    gap: 15px;
-    border: 2px solid var(--primary);
-    border-radius: 12px;
-    padding: 12px 16px;
-    text-decoration: none;
-    color: var(--primary);
-    background-color: transparent;
-}
-
-.user-result-card:hover {
-    background-color: var(--primary);
-    color: var(--surface);
-}
-
-.user-result-avatar,
-.user-result-placeholder {
-    width: 45px;
-    height: 45px;
-    border-radius: 50%;
-    object-fit: cover;
-}
-
-.user-result-placeholder {
-    background-color: var(--text-main);
-}
 /* logout */
 .modal {
     position: fixed;
@@ -1811,20 +1828,21 @@ a:hover, a:active {
     display: none !important;
 }
 
-.modal.hidden {
-    display: none !important;
-}
 /* EMPTY STATE CENTERING */
 .empty-state {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    text-align: center;
     width: 100%;
     min-height: 220px;
     margin: 40px auto;
+    text-align: center;
     color: var(--primary-dark);
+    border: 1px dashed var(--border-soft);
+    border-radius: var(--radius-md);
+    background: var(--surface);
+    box-shadow: var(--shadow-soft);
 }
 
 .empty-state i {
@@ -1843,175 +1861,6 @@ a:hover, a:active {
     grid-column: 1 / -1;
 }
 
-/* follow list styling START */
-
-.follow-stat-link,
-.follow-stat-link:link,
-.follow-stat-link:visited {
-    border: none;
-    padding: 0;
-    color: #555;
-    text-decoration: none;
-    display: inline;
-}
-
-.follow-stat-link:hover {
-    background-color: transparent;
-    color: var(--primary);
-    text-decoration: underline;
-}
-
-.follow-list-container {
-    max-width: 700px;
-    margin: 30px auto;
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-}
-
-.follow-list-card,
-.follow-list-card:link,
-.follow-list-card:visited {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    border: 2px solid var(--primary);
-    border-radius: 14px;
-    padding: 14px 18px;
-    background-color: var(--surface);
-    color: var(--text-main);
-    text-decoration: none;
-    text-align: left;
-}
-
-.follow-list-card:hover {
-    background-color: var(--primary);
-    color: var(--surface);
-}
-
-.follow-list-avatar,
-.follow-list-placeholder {
-    width: 58px;
-    height: 58px;
-    border-radius: 50%;
-    object-fit: cover;
-    flex-shrink: 0;
-}
-
-.follow-list-placeholder {
-    background-color: var(--text-main);
-}
-
-.follow-list-info h2 {
-    margin: 0;
-    color: inherit;
-    font-size: 20px;
-}
-
-.follow-list-info p {
-    margin: 4px 0 0 0;
-    font-size: 14px;
-}
-
-/* follow list styling END */
-
-/* remember password row */
-.remember-row label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-weight: normal;
-}
-
-.remember-row input {
-    width: auto;
-}
-
-/*notifications styling start*/
-.notifications-container {
-    max-width: 700px;
-    margin: 30px auto;
-}
-
-.notification-card {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 15px;
-    border: 2px solid var(--primary);
-    border-radius: 14px;
-    padding: 14px 18px;
-    margin-bottom: 14px;
-    background: var(--surface);
-    cursor: pointer;
-}
-
-.notification-card:hover {
-    background: var(--surface);
-}
-
-.notification-left {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.notification-left p {
-    margin: 0;
-    color: #222;
-}
-
-.notification-avatar,
-.notification-avatar-placeholder {
-    width: 45px;
-    height: 45px;
-    border-radius: 50%;
-    object-fit: cover;
-}
-
-.notification-avatar-placeholder {
-    background: black;
-}
-
-.notification-actions {
-    display: flex;
-    gap: 8px;
-}
-
-.notification-btn {
-    border: 2px solid var(--primary);
-    border-radius: 8px;
-    padding: 8px 12px;
-    cursor: pointer;
-    font-weight: bold;
-}
-
-.follow-back-btn {
-    background: var(--primary);
-    color: #ededed;
-}
-
-.remove-btn {
-    background: transparent;
-    color: var(--primary);
-}
-
-.following-btn {
-    background: var(--surface);
-    color: #555;
-    border-color: #aaa;
-    cursor: default;
-}
-/*notification styling end*/
-
-/* itinerary form start */
-/* ============================================================
-   TRIP DETAILS HERO — two-column form layout
-   Add these rules to styles.css (replace the old h1/h2 above
-   the form and the plain label/input styles for that section)
-   ============================================================ */
-
-/* Outer two-column container */
 /* itinerary form start */
 
 .trip-details-hero {
@@ -2261,10 +2110,6 @@ a:hover, a:active {
     transition: opacity 0.3s ease;
 }
 
-.save-confirmation.hidden {
-    display: none;
-}
-
 /* css for file photo list */
 .file-list {
     margin-top: 10px;
@@ -2400,16 +2245,27 @@ a:hover, a:active {
     width: 100%;
     max-width: 900px;
     max-height: 700px;
+
     margin: 0 auto 20px auto;
+
     border-radius: 16px;
     overflow: hidden;
-    background: #e6e1e3;
+
+    background: #f8f8f8;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .itinerary-display-page .main-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+
+    object-fit: contain;
+    object-position: center center;
+
+    background: #f8f8f8;
 }
 
 .itinerary-display-page .trip-summary {
@@ -2461,7 +2317,7 @@ a:hover, a:active {
 .itinerary-display-page .day-card img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: cover !important;
 }
 
 .lightbox {
@@ -2659,7 +2515,7 @@ a:hover, a:active {
     display: inline-flex;
     align-items: center;
     outline: none;
-    margin-top: 12px;   /* nudge down to match other icons */
+    margin-top: 12px;   
 }
 
 .action-buttons .edit-button i {
@@ -2678,134 +2534,58 @@ a:hover, a:active {
 
 /* itinerary display page end */
 
-/*message button in user-profile start*/
-.profile-action-buttons {
-    display: flex;
-    gap: 0.75rem;
-    align-items: center;
-    margin-top: 0.5rem;
-}
-
-.profile-action-buttons a.message-button {
+/* Make Follow/Unfollow and Message buttons consistent */
+.profile-action-buttons .follow-button,
+.profile-action-buttons a.message-button,
+.profile-action-buttons a.message-button:link,
+.profile-action-buttons a.message-button:visited {
     width: 130px;
     height: 40px;
-    box-sizing: border-box;
     padding: 0;
     margin: 0;
+    font-size: 16px;
+    font-weight: 800;
+    font-family: Helvetica, Arial, sans-serif;
     line-height: 1;
     border: 2px solid var(--primary);
-    border-radius: 10px;
-    background-color: var(--primary);
-    color: var(--surface);
-    font-weight: bold;
-    text-decoration: none;
-    cursor: pointer;
-    transition: 0.3s;
+    border-radius: 999px;
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    text-decoration: none;
+    cursor: pointer;
+    transition: 0.2s;
 }
 
-.profile-action-buttons a.message-button:hover {
-    background-color: transparent;
+/* Follow button base */
+.profile-action-buttons .follow-button {
+    background: transparent;
     color: var(--primary);
 }
-/*message button end*/
-/* itinerary display page end */
 
-/* Notifications improvements START */
-
-.notification-page-subtitle {
-    color: var(--text-secondary);
-    margin-top: -5px;
-    margin-bottom: 25px;
-}
-
-.notification-card {
-    position: relative;
-}
-
-.notification-text {
-    text-align: left;
-}
-
-.notification-text p {
-    margin: 0;
-}
-
-.notification-hint,
-.notification-preview {
-    display: block;
-    margin-top: 4px;
-    font-size: 13px;
-    color: var(--text-secondary);
-}
-
-.notification-type-icon {
-    color: var(--primary);
-    margin-right: 8px;
-}
-
-.notification-new-badge {
-    position: absolute;
-    top: 10px;
-    right: 12px;
-    background-color: var(--primary);
+/* Message button base */
+.profile-action-buttons a.message-button {
+    background: var(--primary);
     color: var(--surface);
-    font-size: 11px;
-    font-weight: bold;
-    padding: 4px 8px;
-    border-radius: 999px;
 }
+
+/* Follow Hover */
+.profile-action-buttons .follow-button:hover{
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-soft);
+}
+
+/* Message hover */
+.profile-action-buttons a.message-button:hover {
+    background: transparent;
+    color: var(--primary);
+}
+
+/* itinerary display page end */
 
 .nav-link-with-badge {
     position: relative;
-}
-
-.nav-badge {
-    position: absolute;
-    top: 6px;
-    right: 8px;
-    min-width: 18px;
-    height: 18px;
-    padding: 0 5px;
-    border-radius: 999px;
-    background-color: var(--primary);
-    color: var(--surface);
-    font-size: 11px;
-    font-weight: bold;
-    line-height: 18px;
-    text-align: center;
-}
-
-.unread-dot {
-    display: inline-block;
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    background-color: var(--primary);
-    margin-left: 8px;
-}
-
-/* Notifications improvements END */
-
-/* ============================================================
-   UI Improvements V2 START
-   Safe shared UI polish based on latest main
-   ============================================================ */
-
-:root {
-    --primary-soft: #f7e8ed;
-    --surface-soft: #fff8fa;
-    --shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.08);
-    --shadow-hover: 0 14px 32px rgba(0, 0, 0, 0.12);
-    --radius-sm: 10px;
-    --radius-md: 16px;
-    --radius-lg: 24px;
-}
-
-body {
-    background: linear-gradient(135deg, #ffffff 0%, var(--background) 100%) !important;
 }
 
 /* ---------- Shared layout ---------- */
@@ -2816,14 +2596,6 @@ body {
     min-height: 100vh;
     overflow: hidden;
 }
-
-.middle-column {
-    flex: 1;
-    overflow-y: auto;
-    padding: 32px;
-    background: transparent;
-}
-
 .right-column {
     background: var(--surface-soft);
     border-left: 1px solid var(--border-soft);
@@ -2848,14 +2620,30 @@ body {
 }
 
 .navigation-bar li a {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 20px 18px;
     margin: 2px 8px;
+    color: #ededed;
+    text-decoration: none;
     border-radius: 14px;
-    transition: background-color 0.2s ease, transform 0.2s ease;
+    transition:
+        background-color 0.2s ease,
+        transform 0.2s ease;
 }
 
 .navigation-bar li a:hover {
     background-color: rgba(255, 255, 255, 0.14);
+    color: #ededed;
     transform: translateX(2px);
+}
+
+.navigation-bar li a i {
+    width: 20px;
+    flex-shrink: 0;
+    text-align: center;
+    font-size: 1.1rem;
 }
 
 .nav-badge {
@@ -2893,13 +2681,6 @@ body {
     transform: translateY(-4px);
     box-shadow: var(--shadow-hover);
     filter: brightness(0.82);
-}
-
-.itinerary-thumbnail {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
 }
 
 /* Overlay should be visible on cards */
@@ -2980,26 +2761,6 @@ body {
     margin-top: 0;
 }
 
-/* ---------- User search cards ---------- */
-
-.user-result-card,
-.user-result-card:link,
-.user-result-card:visited {
-    border: 1px solid var(--border-soft) !important;
-    border-radius: var(--radius-md);
-    background-color: var(--surface);
-    box-shadow: var(--shadow-soft);
-    color: var(--text-main);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.user-result-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-hover);
-    background-color: var(--surface);
-    color: var(--primary);
-}
-
 /* ---------- Profile page ---------- */
 
 .profile-section {
@@ -3015,36 +2776,6 @@ body {
     color: var(--primary);
 }
 
-.follow-button,
-.profile-action-buttons a.message-button {
-    border-radius: 999px !important;
-}
-
-.profile-action-buttons {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    margin-left: 40px;
-}
-
-.profile-action-buttons a.message-button {
-    width: 130px;
-    height: 40px;
-    border: 2px solid var(--primary);
-    background: var(--primary);
-    color: var(--surface);
-    font-weight: bold;
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.profile-action-buttons a.message-button:hover {
-    background: transparent;
-    color: var(--primary);
-}
-
 .bio {
     max-width: 900px;
     margin: 20px auto !important;
@@ -3056,79 +2787,9 @@ body {
     color: var(--text-main);
 }
 
-.profile-tabs {
-    width: fit-content;
-    margin: 30px auto 18px;
-    padding: 8px 18px;
-    border-radius: 999px;
-    background: var(--surface);
-    box-shadow: var(--shadow-soft);
-}
-
-/* ---------- Follow list ---------- */
-
-.follow-list-container {
-    max-width: 820px;
-}
-
-.follow-list-card,
-.follow-list-card:link,
-.follow-list-card:visited {
-    border: 1px solid var(--border-soft) !important;
-    border-radius: var(--radius-md);
-    background: var(--surface);
-    box-shadow: var(--shadow-soft);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.follow-list-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-hover);
-    background: var(--surface);
-    color: var(--primary);
-}
 
 /* ---------- Notifications ---------- */
 
-.notification-page-subtitle {
-    color: var(--text-secondary);
-    margin-top: -5px;
-    margin-bottom: 25px;
-}
-
-.notifications-container {
-    max-width: 880px;
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-}
-
-.notification-card {
-    border: 1px solid var(--border-soft);
-    border-radius: var(--radius-md);
-    background: var(--surface);
-    box-shadow: var(--shadow-soft);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.notification-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-hover);
-}
-
-.notification-type-icon {
-    color: var(--primary);
-    margin-right: 8px;
-}
-
-.notification-hint,
-.notification-preview {
-    display: block;
-    margin-top: 4px;
-    font-size: 13px;
-    color: var(--text-secondary);
-    text-align: left;
-}
 
 .notification-new-badge {
     background: #f59e0b;
@@ -3137,92 +2798,10 @@ body {
     font-weight: 900;
     padding: 4px 9px;
     border-radius: 999px;
-}
-
-/* ---------- DMs page ---------- */
-
-.dms-body {
-    background: var(--background) !important;
-}
-
-.dms-body .page-wrapper {
-    height: 100vh;
-}
-
-.dms-sidebar {
-    background: var(--surface);
-    border-right: 1px solid var(--border-soft);
-    box-shadow: 4px 0 16px rgba(0, 0, 0, 0.04);
-}
-
-.dms-sidebar-title {
-    color: var(--primary);
-    text-align: left;
-}
-
-#userList {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.user {
-    display: flex !important;
-    align-items: center;
-    justify-content: space-between;
-    border: 1px solid var(--border-soft);
-    border-radius: var(--radius-md);
-    background: var(--surface-soft);
-    color: var(--text-main);
-    font-weight: 700;
-    box-shadow: none;
-}
-
-.user:hover,
-.user.active-user {
-    background: var(--primary-soft);
-    color: var(--primary);
-    box-shadow: var(--shadow-soft);
-}
-
-.unread-dot {
-    background: #f59e0b;
-    box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.18);
-}
-
-.dms-chat-header {
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-soft);
-    color: var(--primary);
-}
-
-.dms-message {
-    box-shadow: 0 5px 18px rgba(0, 0, 0, 0.07);
-}
-
-.dms-mine {
-    background: var(--primary);
-    color: var(--surface);
-}
-
-.dms-theirs {
-    background: var(--surface);
-    border: 1px solid var(--border-soft);
-}
-
-.dms-composer {
-    border-top: 1px solid var(--border-soft);
-}
-
-.dms-composer input {
-    border-radius: 999px;
-    border: 1.5px solid var(--border-soft);
-}
-
-.dms-composer button {
-    border-radius: 999px;
-    background: var(--primary);
-    color: var(--surface);
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    background-color: var(--primary);
 }
 
 /* ---------- Login / Username safe polish ---------- */
@@ -3250,29 +2829,6 @@ body {
     border-radius: 999px;
 }
 
-/* ---------- Itinerary display fixes ---------- */
-
-/* Main itinerary image: show full image instead of cropping too much */
-.itinerary-display-page .main-image {
-    background: #f8f8f8;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.itinerary-display-page .main-image img {
-    width: 100% !important;
-    height: 100% !important;
-    object-fit: contain !important;
-    object-position: center center !important;
-    background: #f8f8f8;
-}
-
-/* Keep day thumbnails cropped */
-.itinerary-display-page .day-card img {
-    object-fit: cover !important;
-}
-
 /* Right column text contrast */
 .right-column .itinerary-detail-box,
 .right-column .itinerary-detail-box .detail-content,
@@ -3294,14 +2850,6 @@ body {
 .step .step-title,
 .step .step-desc {
     color: #ffffff !important;
-}
-
-/* Empty states */
-.empty-state {
-    border: 1px dashed var(--border-soft);
-    border-radius: var(--radius-md);
-    background: var(--surface);
-    box-shadow: var(--shadow-soft);
 }
 
 /* ---------- Responsive ---------- */
@@ -3502,7 +3050,7 @@ body {
     border: 1px solid var(--border-soft) !important;
     border-radius: var(--radius-md);
     padding: 14px 18px;
-    color: var(--text-main);
+    color: var(--primary);
     background-color: var(--surface);
     box-shadow: var(--shadow-soft);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -3575,14 +3123,6 @@ body {
    Profile / Follow / Notifications UI V2 START
    ============================================================ */
 
-:root {
-    --primary-soft: #f7e8ed;
-    --surface-soft: #fff8fa;
-    --shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.08);
-    --shadow-hover: 0 14px 32px rgba(0, 0, 0, 0.12);
-    --radius-md: 16px;
-    --radius-lg: 24px;
-}
 
 /* ---------- Profile page ---------- */
 
@@ -3660,6 +3200,8 @@ body {
     color: var(--text-secondary);
     font-weight: 700;
     background: transparent;
+    text-decoration: none;
+    display: inline;
 }
 
 .follow-stat-link:hover {
@@ -3670,45 +3212,6 @@ body {
 
 .follow-divider {
     color: var(--border-soft);
-}
-
-.profile-action-buttons {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    margin: 0 !important;
-}
-
-.follow-button,
-.profile-action-buttons a.message-button {
-    margin: 0 !important;
-    width: auto;
-    min-width: 120px;
-    height: 42px;
-    padding: 0 22px;
-    border-radius: 999px !important;
-    font-weight: 800;
-}
-
-.follow-button:hover,
-.profile-action-buttons a.message-button:hover {
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-soft);
-}
-
-.profile-action-buttons a.message-button {
-    border: 2px solid var(--primary);
-    background: var(--primary);
-    color: var(--surface);
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.profile-action-buttons a.message-button:hover {
-    background: transparent;
-    color: var(--primary);
 }
 
 .bio-wrapper {
@@ -3753,12 +3256,14 @@ body {
 .profile-tab {
     width: 46px;
     height: 40px;
+    background: transparent;
     border: none;
     border-radius: 999px;
-    background: transparent;
-    color: var(--text-secondary);
     cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    font-size: 26px;
+    color: var(--text-secondary);
+    padding-bottom: 8px;
+    transition:background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 .profile-tab:hover {
@@ -3794,12 +3299,12 @@ body {
     border: 1px solid var(--border-soft) !important;
     border-radius: var(--radius-lg);
     padding: 18px 22px;
-    background:
-            linear-gradient(135deg, #ffffff, var(--surface-soft));
+    background: linear-gradient(135deg, #ffffff, var(--surface-soft));
     color: var(--text-main);
     box-shadow: var(--shadow-soft);
     display: flex;
     align-items: center;
+    text-align: left;
     gap: 18px;
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
@@ -3808,8 +3313,7 @@ body {
     transform: translateY(-3px);
     box-shadow: var(--shadow-hover);
     border-color: var(--primary) !important;
-    background:
-            linear-gradient(135deg, #ffffff, var(--primary-soft));
+    background: linear-gradient(135deg, #ffffff, var(--primary-soft));
     color: var(--text-main);
 }
 
@@ -3842,6 +3346,7 @@ body {
 .follow-list-info p {
     margin: 0;
     color: var(--text-secondary);
+    font-size: 14px;
     line-height: 1.5;
 }
 
@@ -4023,11 +3528,6 @@ body {
    DMs Page UI V2 START
    ============================================================ */
 
-.dms-body {
-    background:
-            radial-gradient(circle at top left, rgba(165, 0, 52, 0.08), transparent 32%),
-            linear-gradient(135deg, #ffffff 0%, var(--background) 100%) !important;
-}
 
 .dms-page-wrapper {
     margin-left: 56px !important;
@@ -4038,50 +3538,6 @@ body {
 }
 
 /* Sidebar */
-
-.dms-sidebar {
-    width: 330px;
-    min-width: 300px;
-    background: var(--surface);
-    border-right: 1px solid var(--border-soft);
-    padding: 24px 20px;
-    overflow-y: auto;
-    box-shadow: 6px 0 22px rgba(0, 0, 0, 0.05);
-}
-
-.dms-sidebar-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 8px;
-}
-
-.dms-sidebar-title {
-    margin: 4px 0 0;
-    text-align: left;
-    color: var(--primary);
-    font-size: 28px;
-}
-
-.dms-sidebar-icon {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-    background: var(--primary-soft);
-    color: var(--primary);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 20px;
-}
-
-.dms-sidebar-subtitle {
-    text-align: left;
-    color: var(--text-secondary);
-    font-size: 14px;
-    line-height: 1.5;
-    margin: 8px 0 20px;
-}
 
 .dms-user-list {
     display: flex;
@@ -4156,302 +3612,10 @@ body {
     flex-shrink: 0;
 }
 
-/* Chat area */
-
-.dms-chat-area {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    background:
-            radial-gradient(circle at top right, rgba(165, 0, 52, 0.06), transparent 30%),
-            var(--background);
-}
-
-.dms-chat-header {
-    min-height: 76px;
-    padding: 20px 28px;
-    background: rgba(255, 255, 255, 0.88);
-    backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--border-soft);
-    color: var(--primary);
-    font-size: 18px;
-    font-weight: 800;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.04);
-}
-
 .dms-chat-placeholder-header {
     display: flex;
     align-items: center;
     gap: 10px;
-}
-
-.chat-profile-link,
-.chat-profile-link:link,
-.chat-profile-link:visited {
-    color: var(--primary);
-    font-weight: 900;
-    border: none !important;
-    padding: 0 !important;
-    background: transparent;
-    text-decoration: none;
-}
-
-.chat-profile-link:hover {
-    color: var(--primary-dark);
-    background: transparent;
-}
-
-/* Messages */
-
-.dms-messages {
-    flex: 1;
-    padding: 30px 32px;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.dms-empty {
-    max-width: 420px;
-    margin: auto;
-    padding: 42px 28px;
-    border-radius: 24px;
-    background: var(--surface);
-    border: 1px dashed var(--border-soft);
-    color: var(--text-secondary);
-    box-shadow: var(--shadow-soft);
-}
-
-.dms-empty i {
-    font-size: 42px;
-    color: var(--primary);
-    margin-bottom: 12px;
-}
-
-.dms-empty p {
-    margin: 0;
-    font-weight: 700;
-}
-
-.date-separator {
-    align-self: center;
-    background: var(--surface);
-    color: var(--text-secondary);
-    border: 1px solid var(--border-soft);
-    border-radius: 999px;
-    padding: 7px 16px;
-    font-size: 13px;
-    margin: 18px 0;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.04);
-}
-
-.dms-message-wrapper {
-    max-width: 68%;
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-}
-
-.mine-wrapper {
-    align-self: flex-end;
-    align-items: flex-end;
-}
-
-.theirs-wrapper {
-    align-self: flex-start;
-    align-items: flex-start;
-}
-
-.dms-message {
-    padding: 12px 15px;
-    border-radius: 18px;
-    font-size: 14px;
-    line-height: 1.5;
-    word-break: break-word;
-    text-align: left;
-    box-shadow: 0 5px 18px rgba(0, 0, 0, 0.07);
-}
-
-.dms-mine {
-    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-    color: var(--surface);
-    border-bottom-right-radius: 6px;
-}
-
-.dms-theirs {
-    background: var(--surface);
-    color: var(--text-main);
-    border: 1px solid var(--border-soft);
-    border-bottom-left-radius: 6px;
-}
-
-.message-time {
-    margin-top: 5px;
-    font-size: 11px;
-    opacity: 0.75;
-    text-align: right;
-}
-
-.dms-theirs .message-time {
-    color: var(--text-secondary);
-}
-
-.dms-mine .message-time {
-    color: rgba(255, 255, 255, 0.82);
-}
-
-/* Reply and reactions */
-
-.reply-btn {
-    border: none;
-    background: transparent;
-    color: var(--primary);
-    font-size: 12px;
-    font-weight: 700;
-    padding: 0 4px;
-    cursor: pointer;
-    opacity: 0.75;
-    transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.reply-btn:hover {
-    opacity: 1;
-    transform: translateY(-1px);
-}
-
-.reply-box {
-    margin-bottom: 8px;
-    padding: 8px 10px;
-    border-left: 4px solid rgba(255, 255, 255, 0.65);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.14);
-    font-size: 12px;
-    opacity: 0.9;
-}
-
-.dms-theirs .reply-box {
-    background: var(--primary-soft);
-    border-left-color: var(--primary);
-    color: var(--text-secondary);
-}
-
-.reply-preview {
-    margin: 0 22px 12px;
-    padding: 12px 16px;
-    border-left: 4px solid var(--primary);
-    background: var(--surface);
-    border-radius: 14px;
-    color: var(--text-secondary);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    box-shadow: var(--shadow-soft);
-}
-
-.reply-preview button {
-    border: none;
-    background: transparent;
-    color: var(--primary);
-    font-weight: 900;
-    cursor: pointer;
-}
-
-.reaction-bar {
-    display: flex;
-    gap: 5px;
-    margin-bottom: 2px;
-    opacity: 0;
-    transform: translateY(4px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.dms-message-wrapper:hover .reaction-bar {
-    opacity: 1;
-    transform: translateY(0);
-}
-
-.reaction-btn {
-    border: 1px solid var(--border-soft);
-    background: var(--surface);
-    border-radius: 999px;
-    padding: 3px 6px;
-    font-size: 13px;
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.reaction-btn:hover {
-    transform: translateY(-1px) scale(1.06);
-    box-shadow: var(--shadow-soft);
-}
-
-.message-reaction {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 6px;
-    background: var(--surface);
-    border: 1px solid var(--border-soft);
-    border-radius: 999px;
-    padding: 2px 6px;
-    font-size: 14px;
-}
-
-/* Composer */
-
-.dms-composer {
-    display: flex;
-    gap: 12px;
-    padding: 18px 22px;
-    background: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(12px);
-    border-top: 1px solid var(--border-soft);
-}
-
-.dms-composer input {
-    flex: 1;
-    height: 48px;
-    border-radius: 999px;
-    padding: 0 18px;
-    border: 1.5px solid var(--border-soft);
-    background: var(--surface);
-}
-
-.dms-composer input:disabled {
-    background: #f1f1f1;
-    color: #999;
-}
-
-.dms-composer button {
-    min-width: 105px;
-    height: 48px;
-    border: none;
-    border-radius: 999px;
-    background: var(--primary);
-    color: var(--surface);
-    font-weight: 900;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    cursor: pointer;
-    transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.dms-composer button:hover:not(:disabled) {
-    background: var(--primary-dark);
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-soft);
-}
-
-.dms-composer button:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
 }
 
 /* Mobile */
@@ -4731,6 +3895,10 @@ body {
     position: sticky;
     top: 0;
     z-index: 20;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 40px;
     background: rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(12px);
     border-bottom: 1px solid var(--border-soft);
@@ -4911,28 +4079,6 @@ body {
     color: var(--text-main);
 }
 
-.how-it-works .steps-container {
-    flex-wrap: wrap;
-}
-
-.how-it-works .step {
-    box-shadow: var(--shadow-soft);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.how-it-works .step:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-hover);
-}
-
-.how-it-works .step,
-.how-it-works .step p,
-.how-it-works .step-title,
-.how-it-works .step-desc,
-.how-it-works .step-number {
-    color: #ffffff !important;
-}
-
 @media (max-width: 950px) {
     .homepage-hero h1 {
         font-size: 42px;
@@ -5038,23 +4184,4 @@ body {
 .profile-info .bio-wrapper .tooltip-text {
     left: 0;
     transform: none;
-}
-/* Make Follow/Unfollow and Message buttons consistent */
-.profile-action-buttons .follow-button,
-.profile-action-buttons a.message-button,
-.profile-action-buttons a.message-button:link,
-.profile-action-buttons a.message-button:visited {
-    width: 130px !important;
-    height: 40px !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    font-size: 16px !important;
-    font-weight: 800 !important;
-    font-family: Helvetica, Arial, sans-serif !important;
-    line-height: 1 !important;
-    border-radius: 999px !important;
-    display: inline-flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    box-sizing: border-box !important;
 }

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -28,7 +28,6 @@
     </p>
 </section>
 
-<!-- UI IMPROVE  -->
 <section class="homepage-section">
     <div class="homepage-section-heading">
         <p class="eyebrow">Popular ideas</p>
@@ -36,80 +35,58 @@
     </div>
 
     <div class="trending-itinerary-container homepage-card-grid">
-        <a class="card-link" href="{{ url_for('itinerary_display', itinerary_id=1) }}">
-            <div class="itinerary-card homepage-travel-card">
-                <div class="card-placeholder"></div>
-                <div class="overlay-text">Tokyo Budget Trip</div>
-            </div>
-            <div class="card-info">
-                <p class="card-title">Tokyo Budget Trip</p>
-                <p class="card-meta"><i class="fa-regular fa-calendar"></i> 7 Days</p>
-                <p class="card-meta"><i class="fa-solid fa-location-dot"></i> Tokyo, Japan</p>
-            </div>
-        </a>
+        {% if popular_itineraries %}
+            {% for itinerary in popular_itineraries %}
+                <a class="card-link" href="{{ url_for('itinerary_display', itinerary_id=itinerary.id) }}">
 
-        <a class="card-link" href="{{ url_for('itinerary_display', itinerary_id=2) }}">
-            <div class="itinerary-card homepage-travel-card">
-                <div class="card-placeholder"></div>
-                <div class="overlay-text">Kyoto Cultural Journey</div>
-            </div>
-            <div class="card-info">
-                <p class="card-title">Kyoto Cultural Journey</p>
-                <p class="card-meta"><i class="fa-regular fa-calendar"></i> 5 Days</p>
-                <p class="card-meta"><i class="fa-solid fa-location-dot"></i> Kyoto, Japan</p>
-            </div>
-        </a>
+                    <div class="itinerary-card homepage-travel-card">
 
-        <a class="card-link" href="{{ url_for('itinerary_display', itinerary_id=3) }}">
-            <div class="itinerary-card homepage-travel-card">
-                <div class="card-placeholder"></div>
-                <div class="overlay-text">Seoul Food Adventure</div>
+                        {% if itinerary.thumbnail %}
+                            <img
+                                src="{{ url_for('static', filename='uploads/' + itinerary.thumbnail) }}"
+                                class="itinerary-thumbnail"
+                                alt="{{ itinerary.title }}"
+                            >
+                        {% else %}
+                            <div class="card-placeholder"></div>
+                        {% endif %}
+
+                        <div class="overlay-text">
+                            {{ itinerary.title }}
+                        </div>
+                    </div>
+
+                    <div class="card-info">
+                        <p class="card-title">{{ itinerary.title }}</p>
+                        <p class="card-meta">
+                            <i class="fa-regular fa-calendar"></i>
+                            {{ (itinerary.end_date - itinerary.start_date).days + 1 }} Days
+                        </p>
+                        <p class="card-meta">
+                            <i class="fa-solid fa-location-dot"></i>
+                            {{ itinerary.destination }}
+                        </p>
+                        <p class="card-meta">
+                            <i class="fa-solid fa-heart"></i>
+                            {{ itinerary.like_count }}
+                            {% if itinerary.like_count == 1 %}
+                                like
+                            {% else %}
+                                likes
+                            {% endif %}
+                        </p>
+                    </div>
+                </a>
+            {% endfor %}
+        {% else %}
+            <div class="empty-state">
+                <i class="fa-solid fa-map"></i>
+                <p>No popular itineraries yet.</p>
             </div>
-            <div class="card-info">
-                <p class="card-title">Seoul Food Adventure</p>
-                <p class="card-meta"><i class="fa-regular fa-calendar"></i> 5 Days</p>
-                <p class="card-meta"><i class="fa-solid fa-location-dot"></i> Seoul, South Korea</p>
-            </div>
-        </a>
+        {% endif %}
     </div>
 </section>
-<!-- ============= -->
-<div class="trending-itinerary-container">
-    {% if popular_itineraries %}
-        {% for itinerary in popular_itineraries %}
-            <a class="card-link" href="{{ url_for('itinerary_display', itinerary_id=itinerary.id) }}">
-                <div class="itinerary-card">
-                    {% if itinerary.thumbnail %}
-                        <img
-                            src="{{ url_for('static', filename='uploads/' + itinerary.thumbnail) }}"
-                            class="itinerary-thumbnail"
-                            alt="{{ itinerary.title }}"
-                        >
-                    {% endif %}
 
-                    <div class="overlay-text">{{ itinerary.title }}</div>
-                </div>
-
-                <div class="card-info">
-                    <p class="card-title">{{ itinerary.title }}</p>
-                    <p class="card-meta">
-                        {{ (itinerary.end_date - itinerary.start_date).days + 1 }} Days
-                    </p>
-                    <p class="card-meta">{{ itinerary.destination }}</p>
-                    <p class="card-meta">
-                        {{ itinerary.like_count }} {% if itinerary.like_count == 1 %}like{% else %}likes{% endif %}
-                    </p>
-                </div>
-            </a>
-        {% endfor %}
-    {% else %}
-        <div class="empty-state">
-            <i class="fa-solid fa-map"></i>
-            <p>No popular itineraries yet.</p>
-        </div>
-    {% endif %}
-</div>
-<!-- homepage itineraries change  -->
 <section class="homepage-section">
     <div class="homepage-section-heading">
         <p class="eyebrow">Why join</p>


### PR DESCRIPTION
This PR refactors and cleans up duplicated CSS across the frontend.

Changes:
removed unused and outdated CSS blocks
consolidated duplicated component styles into single reusable definitions
removed overridden styles and unnecessary legacy rules
improved consistency across homepage, profile, feed, search, and notifications pages


reduced stylesheet size and duplication
improves maintainability and readability
makes styling behaviour more predictable
keeps shared UI components visually consistent across the application